### PR TITLE
Added github action to tags

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,69 @@
+# -------------------------------------------------------------------------------------
+# Copyright 2020 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+# This file is part of Pentaho DSP.
+# Pentaho DSP is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# Pentaho DSP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this software. If not, see http://www.gnu.org/licenses/.
+# For those usages not covered by this license please contact with
+# sc_support at telefonica dot com
+# -------------------------------------------------------------------------------------
+
+name: Maven Build
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    # Standard steps - check out repo & build with maven
+    - name: Checkout repo
+      uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Initialize Maven
+      run: mvn -B initialize
+    - name: Build with Maven
+      run: mvn -B package
+
+    # Create a release for the current tag
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    # Get tag name. strip the initial "v"
+    - name: Get Version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+
+    # Upload compiled jar to the release
+    - name: Upload Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./target/pentaho-dsp-${{ steps.get_version.outputs.VERSION }}.jar
+        asset_name: pentaho-dsp-${{ steps.get_version.outputs.VERSION }}.jar
+        asset_content_type: application/java-archive

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,7 +51,7 @@ jobs:
         draft: false
         prerelease: false
 
-    # Get tag name. strip the initial "v"
+    # Get tag name.
     - name: Get Version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -67,3 +67,4 @@ jobs:
         asset_path: ./target/pentaho-dsp-${{ steps.get_version.outputs.VERSION }}.jar
         asset_name: pentaho-dsp-${{ steps.get_version.outputs.VERSION }}.jar
         asset_content_type: application/java-archive
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ name: Maven Build
 on:
   push:
     tags:
-    - 'v*'
+    - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -54,7 +54,7 @@ jobs:
     # Get tag name. strip the initial "v"
     - name: Get Version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
     # Upload compiled jar to the release
     - name: Upload Asset

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Este proyecto utiliza [Github Actions](https://github.com/features/actions) para
 - Crear un tag git con el número de versión
 
 ```bash
-git tag -a vA.B.C -m "Versión A.B.C"
+git tag -a A.B.C -m "Versión A.B.C"
 git push --tags
 ```
 
-Nótese que el número de versión **lleva un prefijo "v" en el tag git, pero no en el pom.xml**. Esto es por prácticas comunes tanto en Maven como en Git.
+El número de versión y el nombre del tag deben coincidir, para que la accion automática se complete con éxito.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Para generar el fichero `.jar` únicamente es necesario ejecutar los siguientes 
 
 # Releases
 
-Este proyecto utiliza [Github Actions](ihttps://github.com/features/actions) para construir automáticamente un archivo jar con cada release. Para liberar una nueva versión, es necesario:
+Este proyecto utiliza [Github Actions](https://github.com/features/actions) para construir automáticamente un archivo jar con cada release. Para liberar una nueva versión, es necesario:
 
 - Modificar el número de versión en el atributo <Version> del fichero pom.xml:
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,35 @@ pentaho-dsp es una librería que extiende Pentaho y que permite reutilizar esque
 La librería reemplaza al vuelo el esquema de la base de datos por el nombre de usuario de la sesión de Pentaho.  
   
 # Build
-  Para generar el fichero `.jar` únicamente es necesario ejecutar los siguientes comandos Maven en el orden indicado:
-  
- 1. `mvn clean`  
- 2. `mvn compile`  
+
+Para generar el fichero `.jar` únicamente es necesario ejecutar los siguientes comandos Maven en el orden indicado:
+
+ 1. `mvn initialize`
+ 1. `mvn clean`
+ 2. `mvn compile`
  3. `mvn clean package`
 
 # Directorios
 
  - **lib**: Almacena una copia de las librerias necesarias para el desarrollo que no se encuentran en el repositorio Maven.
- - **src**: Almacena el cógido java
+ - **src**: Almacena el código java
+
+# Releases
+
+Este proyecto utiliza [Github Actions](ihttps://github.com/features/actions) para construir automáticamente un archivo jar con cada release. Para liberar una nueva versión, es necesario:
+
+- Modificar el número de versión en el atributo <Version> del fichero pom.xml:
+
+```xml
+<version>A.B.C</version>
+```
+
+- Hacer commit de los cambios
+- Crear un tag git con el número de versión
+
+```bash
+git tag -a vA.B.C -m "Versión A.B.C"
+git push --tags
+```
+
+Nótese que el número de versión **lleva un prefijo "v" en el tag git, pero no en el pom.xml**. Esto es por prácticas comunes tanto en Maven como en Git.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Este proyecto utiliza [Github Actions](https://github.com/features/actions) para
 <version>A.B.C</version>
 ```
 
-- Hacer commit de los cambios
+- Hacer commit y push de los cambios
 - Crear un tag git con el número de versión
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <build>
         <plugins>
             <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <archive>
@@ -50,6 +51,49 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
+            </plugin>
+            <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-install-plugin</artifactId>
+		<version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+			<goals><goal>install-file</goal></goals>
+                        <id>mondrian</id>
+                        <configuration>
+                            <file>lib/mondrian-3.0.jar</file>
+                            <groupId>mondrian</groupId>
+                            <artifactId>mondrian</artifactId>
+                            <version>3.0</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals><goal>install-file</goal></goals>
+                        <id>pentaho-platform-core</id>
+                        <configuration>
+                            <file>lib/pentaho-platform-core-8.2.0.0-342.jar</file>
+                            <groupId>pentaho</groupId>
+                            <artifactId>pentaho-platform-core</artifactId>
+                            <version>8.2.0.0-342</version>
+                           <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals><goal>install-file</goal></goals>
+                        <id>pentaho-platform-api</id>
+                        <configuration>
+                            <file>lib/pentaho-platform-api-8.2.0.1-427.jar</file>
+                            <groupId>pentaho</groupId>
+                            <artifactId>pentaho-platform-api</artifactId>
+                            <version>8.2.0.1-427</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                     </execution>
+                 </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Este PR añade una [acción de Github](https://github.com/features/actions) que automáticamente compila el fichero **.jar** y lo publica como una [release](https://help.github.com/en/github/administering-a-repository/creating-releases), cada vez que se etiqueta una nueva versión.

Para que la acción funcione, es necesario que:

- El número de versión (A.B.C) se actualice en la etiqueta `<version>` del fichero `pom.xml`
- Se haga commit de los cambios.
- Se cree en github un tag con el mismo número de versión (e.g. `A.B.C`).