### PR TITLE
Removed writes to internal volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,11 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Editros
+# Editors
 .classpath
 .project
 .idea
+settings.json
 *.iml
 *.prefs
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@
 .mtj.tmp/
 
 # Editros
+.classpath
+.project
 .idea
 *.iml
+*.prefs
 
 # Compiled files
 target

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # sc_support at telefonica dot com
 
-FROM fivecorp/pentaho-env:v8.3.6
+FROM fivecorp/pentaho-env:v8.3.7
 
 LABEL maintainer=telefonicasc
 

--- a/hooks/pentaho-dsp.sh
+++ b/hooks/pentaho-dsp.sh
@@ -27,9 +27,9 @@ if [ -f "${LIBDIR}/pentaho-dsp.jar" ]; then
 fi
 
 echo "COMPILANDO pentaho-dsp.jar"
-cd /home/pentaho; mkdir dist
-find src -name "*.java" | xargs javac -d ./dist -cp "${LIBDIR}/*"
-cd dist; jar cvf pentaho-dsp.jar org
+mkdir -p /tmp/dist && cd /tmp/dist
+find /home/pentaho/src -name "*.java" | xargs javac -d /tmp/dist -cp "${LIBDIR}/*"
+jar cvf pentaho-dsp.jar org
 
 echo "INSTALANDO pentaho-dsp.jar"
 mv pentaho-dsp.jar "${LIBDIR}/"

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.telefonica.urbo2</groupId>
     <artifactId>pentaho-dsp</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Al intentar desplegar un contenedor de Pentaho en openshift, tenemos problemas para crear ficheros  en /home/pentaho, porque el UID con el que openshift ejecuta el contenedor no es el esperado (1000), sino el asignado al proyecto (aleatorio).

En lugar de tener que ejecutar el contenedor con un SCC privilegiado para forzar el UID, hemos preferido usar /tmp para todo lo que involucre crear o escribir ficheros. De esta forma, /tmp se puede montar como volumen y se evita el problema.