### PR TITLE
Agregada personalización de página de login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ LABEL maintainer=telefonicasc
 # Add config hooks to /opt
 USER root
 ADD hooks /opt/hooks/
-RUN chmod 0755 /opt/hooks/*.sh
+RUN chmod a+r /opt/hooks/* && chmod a+rx /opt/hooks/*.sh
 
 # Add source code to /home/pentaho
 USER pentaho

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ LABEL maintainer=telefonicasc
 # Add config hooks to /opt
 USER root
 ADD hooks /opt/hooks/
+RUN chmod 0755 /opt/hooks/*.sh
 
 # Add source code to /home/pentaho
 USER pentaho

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # sc_support at telefonica dot com
 
-FROM fivecorp/pentaho-env:v8.3.8
+FROM fivecorp/pentaho-env:v8.3.10
 
 LABEL maintainer=telefonicasc
 

--- a/hooks/tapa-customization.sh
+++ b/hooks/tapa-customization.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+#
+# This file is part of Pentaho DSP.
+#
+# Pentaho DSP is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Pentaho DSP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# sc_support at telefonica dot com
+
+set -eoux pipefail
+
+cd "${PENTAHO_HOME}"
+echo "DESCOMPRIMIENDO customizaciones de interfaz (Tapa)"
+tar -xjvf /opt/hooks/tapa-customization.tbz

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.telefonica.urbo2</groupId>
     <artifactId>pentaho-dsp</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Este PR añade a Pentaho un plugin (tapa) para la personalización de la pantalla de login, e incluye una nueva ventana de login diseñada con imagen corporativa de Telefónica.

Adicionalmente, se incrementa la imagen base de pentaho para incluir un fix que evita que el fichero de access log (que no estaba siendo rotado) desborde la capacidad del volumen.

![image](https://user-images.githubusercontent.com/52279456/98260532-ba32cb80-1f83-11eb-822d-44669730ecbe.png)
