### PR TITLE
Bumped base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # sc_support at telefonica dot com
 
-FROM fivecorp/pentaho-env:v8.3.10
+FROM fivecorp/pentaho-env:v8.3.11
 
 LABEL maintainer=telefonicasc
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.telefonica.urbo2</groupId>
     <artifactId>pentaho-dsp</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.telefonica.urbo2</groupId>
     <artifactId>pentaho-dsp</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Actualiza la versión base de la imagen de Pentaho, para soportar atributos adicionales en CATALINA_OPTS (como -Duser.timezone=Europe/Madrid)